### PR TITLE
fixes api authentication

### DIFF
--- a/app/controllers/api/punches_controller.rb
+++ b/app/controllers/api/punches_controller.rb
@@ -59,7 +59,10 @@ module Api
     protected
 
     def restrict_access
-      @user = User.find_by(token: params[:user_token]) || User.find_by(slack_username: params[:punch][:user][:slack])
+      @user = User.find_by(token: params[:user_token]) if params[:user_token].present?
+      if (params[:punch][:user][:slack].present? rescue nil)
+        @user ||= User.find_by(slack_username: params[:punch][:user][:slack])
+      end
       if API_TOKEN.blank? || @user.blank? || params[:api_token] != API_TOKEN
         head :unauthorized
       end


### PR DESCRIPTION
O júlio por acaso tinha token=nil e isso causava que toda batida de ponto via API batesse o ponto na conta dele.
Ajustei a autenticação para desconsiderar os casos em que params[:user_token] não estiver presente. Além disso coloquei um rescue para evitar exceções de acesso na hash aninhada.